### PR TITLE
Disable Inline Playback

### DIFF
--- a/Sources/YTPlayerView.m
+++ b/Sources/YTPlayerView.m
@@ -905,7 +905,7 @@ createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration
 
 - (WKWebView *)createNewWebView {
   WKWebViewConfiguration *webViewConfiguration = [[WKWebViewConfiguration alloc] init];
-  webViewConfiguration.allowsInlineMediaPlayback = YES;
+  webViewConfiguration.allowsInlineMediaPlayback = NO;
   webViewConfiguration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
   WKWebView *webView = [[WKWebView alloc] initWithFrame:self.bounds
                                           configuration:webViewConfiguration];


### PR DESCRIPTION
The media player defaults to inline playback when invoked from a programmatic view. This branch disables inline playback for version [1.0.4](https://github.com/youtube/youtube-ios-player-helper/releases/tag/1.0.4).

```swift
import UIKit
import YouTubeiOSPlayerHelper

class ViewController: UIViewController, YTPlayerViewDelegate {

    let playerView: YTPlayerView = {
        var view = YTPlayerView(frame: CGRect(x: 0, y: 0, width: 640, height: 360))
        return view
    }()

    override func viewDidLoad() {
        super.viewDidLoad()

        let videoId = "VIDEO_ID"

        let playerVars = [
            "playsinline" : 0
        ]

        playerView.delegate = self
        playerView.load(withVideoId: videoId, playerVars: playerVars)

        view.addSubview(playerView)
    }
}
```