### PR TITLE
Add Support for Inline or Fullscreen Media Playback

### DIFF
--- a/Sources/YTPlayerView.m
+++ b/Sources/YTPlayerView.m
@@ -741,7 +741,7 @@ createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration
 
   // Remove the existing webview to reset any state
   [self.webView removeFromSuperview];
-  _webView = [self createNewWebView];
+  _webView = [self createNewWebViewAllowsInlineMediaPlayback: [[playerVars objectForKey:@"playsinline"] boolValue]];
   [self addSubview:self.webView];
 
   NSError *error = nil;
@@ -903,9 +903,15 @@ createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration
   _webView = webView;
 }
 
-- (WKWebView *)createNewWebView {
+/**
+ * Creates a web view configured for inline or fullscreen playback
+ *
+ * @param allowsInlineMediaPlayback inline (1) or fullscreen (0 or null) playback
+ * @return WKWebView
+ */
+- (WKWebView *)createNewWebViewAllowsInlineMediaPlayback :(Boolean *)allowsInlineMediaPlayback {
   WKWebViewConfiguration *webViewConfiguration = [[WKWebViewConfiguration alloc] init];
-  webViewConfiguration.allowsInlineMediaPlayback = YES;
+  webViewConfiguration.allowsInlineMediaPlayback = allowsInlineMediaPlayback;
   webViewConfiguration.mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
   WKWebView *webView = [[WKWebView alloc] initWithFrame:self.bounds
                                           configuration:webViewConfiguration];


### PR DESCRIPTION
The media player defaults to inline playback when invoked from a programmatic view. This branch respects the `playsinline` for version [1.0.4](https://github.com/youtube/youtube-ios-player-helper/releases/tag/1.0.4). The view controller must conform to YTPlayerViewDelegate otherwise the media player will default back to inline playback.

```swift
import UIKit
import YouTubeiOSPlayerHelper

class ViewController: UIViewController, YTPlayerViewDelegate {

    let playerView: YTPlayerView = {
        var view = YTPlayerView(frame: CGRect(x: 0, y: 0, width: 640, height: 360))
        return view
    }()

    override func viewDidLoad() {
        super.viewDidLoad()

        let videoId = "VIDEO_ID"

        let playerVars = [
            "playsinline" : 0
        ]

        playerView.delegate = self
        playerView.load(withVideoId: videoId, playerVars: playerVars)

        view.addSubview(playerView)
    }
}
```